### PR TITLE
test explicitly on julia 0.4 and 0.5 on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,8 @@ os:
   - linux
   - osx
 julia:
-  - release
+  - 0.4
+  - 0.5
   - nightly
 notifications:
   email: false


### PR DESCRIPTION
0.4 still supported according to REQUIRE, should still be tested

note that there's no need to re-tag for this, since it's a travis-only change it won't change what users get