### PR TITLE
Fix evaluation of segintsg to Inf for some cases

### DIFF
--- a/src/WiltonInts84.jl
+++ b/src/WiltonInts84.jl
@@ -25,9 +25,9 @@ include("contour.jl")
         sgn = d < ϵ ? zero(T) : sign(h)
         I1 = abs(p) < ϵ ? z : sgn*(atan((p*b)/(q2+d*rb)) - atan((p*a)/(q2 + d*ra)))
         #j = (q2 < ϵ^2) ? (b > 0 ? log(b/a) : log(a/b)) : log(b + rb) - log(a + ra)
+        a2 = a^2
         b2 = b^2
-        if b < 0 && q2 < b2 * (0.5e-3)^2
-            a2 = a^2
+        if b < 0 && q2 < max(a2,b2) * (0.5e-3)^2
             j = log(a/b) + log((1-(q2/b2)/2) / (1-(q2/a2)/2))
         else
             j = log(b + rb) - log(a + ra)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,6 +3,7 @@ using LinearAlgebra
 include("num_quad.jl")
 
 include("test_triangleints.jl")
+include("test_segintsg.jl")
 include("test_contour0.jl")
 include("test_contour1.jl")
 include("test_contour2.jl")

--- a/test/test_segintsg.jl
+++ b/test/test_segintsg.jl
@@ -1,0 +1,36 @@
+using WiltonInts84
+using Test
+
+using StaticArrays
+using LinearAlgebra
+
+for U in [Float32, Float64]
+    x1 = SVector{3,U}(1.0, 0.0, 0.0)
+    x2 = SVector{3,U}(0.0, 0.0, 0.0)
+    x3 = SVector{3,U}(0.5, sqrt(3)/2, 0.0)
+    x = SVector{3,U}(-0.1, -sqrt(1e-8), 0.0)
+
+
+    ctr=contour(x1, x2, x3, x)
+    n = ctr.normal
+    h = ctr.height
+    ξ = x - h*n
+    UB=Val{1}
+    for j in 1:3
+        a = ctr.segments[j][1]
+        b = ctr.segments[j][2]
+        t = b - a
+        t /= norm(t)
+        m = cross(t, n)
+        p = dot(a-ξ, m)
+        sa = dot(a-ξ, t)
+        sb = dot(b-ξ, t)
+        P, Q = WiltonInts84.segintsg(sa, sb, p, h, m, UB)
+        for i in P
+            @test !isnan(i)
+            @test !isinf(i)
+        end
+    end
+end
+
+


### PR DESCRIPTION
Extended comparison in segintsg of q^2 to both a^2 and b^2 to avoid
singular log at different magnitudes of a and b.

Added a unit test with an example triangle for which segintsg evalutes
to Inf without the change.